### PR TITLE
fix: Add py.typed marker file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
   "pytest",
   "coverage",
   "build",
+  "mypy",
 ]
 
 [project.urls]

--- a/test/test_ordered_enum.py
+++ b/test/test_ordered_enum.py
@@ -75,6 +75,7 @@ def test_total_value_ordering_unsound():
     assert not (X.Foo < X.Bar)
     assert not (X.Foo > X.Bar)
 
+
 def test_mypy_success():
     from mypy import api
 

--- a/test/test_ordered_enum.py
+++ b/test/test_ordered_enum.py
@@ -74,3 +74,10 @@ def test_total_value_ordering_unsound():
 
     assert not (X.Foo < X.Bar)
     assert not (X.Foo > X.Bar)
+
+def test_mypy_success():
+    from mypy import api
+
+    result = api.run([__file__])
+
+    assert "Success: no issues found in 1 source file" in result[0]


### PR DESCRIPTION
This PR makes the package compatible with [PEP 561](https://peps.python.org/pep-0561) adding the required `py.typed` marker file, allowing mypy to traverse this package and extract typing information.

As motivation for this change, assume we have the following file (I'll refer to it as `enum_test.py`):
```python
from ordered_enum import OrderedEnum


class MyEnum(OrderedEnum):
    A = "a"
    B = "b"


def my_enum_func(val: MyEnum):
    print(val)


print(my_enum_func(MyEnum.A))

```

Running mypy over this file yields the following:
```
$ mypy enum_test.py
enum_test.py:1: error: Skipping analyzing "ordered_enum.ordered_enum": module is installed, but missing library stubs or py.typed marker  [import]
enum_test.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
enum_test.py:13: error: Argument 1 to "my_enum_func" has incompatible type "str"; expected "MyEnum"  [arg-type]
```

By adding the required `py.typed` marker file at the top level of the package, mypy is able to traverse it and resolve the type information. This is the mypy output after the changes in my PR:

```
$ mypy enum_test.py 
Success: no issues found in 1 source file
```

I've also included a simple unit test, that basically runs mypy on the test file and checks that there are no errors in the output.