### PR TITLE
Fix: make `OrderedEnum` and `ValueOrderedEnum` considered public

### DIFF
--- a/src/ordered_enum/__init__.py
+++ b/src/ordered_enum/__init__.py
@@ -1,4 +1,5 @@
-from ordered_enum.ordered_enum import OrderedEnum as OrderedEnum
-from ordered_enum.ordered_enum import ValueOrderedEnum as ValueOrderedEnum
+__all__ = ["OrderedEnum", "ValueOrderedEnum", "__version__"]
+from ordered_enum.ordered_enum import OrderedEnum
+from ordered_enum.ordered_enum import ValueOrderedEnum
 
 __version__ = "0.0.8"

--- a/src/ordered_enum/__init__.py
+++ b/src/ordered_enum/__init__.py
@@ -1,5 +1,4 @@
-from ordered_enum.ordered_enum import OrderedEnum
-from ordered_enum.ordered_enum import ValueOrderedEnum
+from ordered_enum.ordered_enum import OrderedEnum, ValueOrderedEnum
 
 __version__ = "0.0.8"
 

--- a/src/ordered_enum/__init__.py
+++ b/src/ordered_enum/__init__.py
@@ -1,4 +1,9 @@
-__all__ = ["OrderedEnum", "ValueOrderedEnum", "__version__"]
+__all__ = [
+    "__version__",
+    "OrderedEnum",
+    "ValueOrderedEnum",
+]
+
 from ordered_enum.ordered_enum import OrderedEnum
 from ordered_enum.ordered_enum import ValueOrderedEnum
 

--- a/src/ordered_enum/__init__.py
+++ b/src/ordered_enum/__init__.py
@@ -1,10 +1,10 @@
+from ordered_enum.ordered_enum import OrderedEnum
+from ordered_enum.ordered_enum import ValueOrderedEnum
+
+__version__ = "0.0.8"
+
 __all__ = [
     "__version__",
     "OrderedEnum",
     "ValueOrderedEnum",
 ]
-
-from ordered_enum.ordered_enum import OrderedEnum
-from ordered_enum.ordered_enum import ValueOrderedEnum
-
-__version__ = "0.0.8"

--- a/src/ordered_enum/__init__.py
+++ b/src/ordered_enum/__init__.py
@@ -1,3 +1,4 @@
-from ordered_enum.ordered_enum import OrderedEnum, ValueOrderedEnum  # noqa: F401
+from ordered_enum.ordered_enum import OrderedEnum as OrderedEnum
+from ordered_enum.ordered_enum import ValueOrderedEnum as ValueOrderedEnum
 
 __version__ = "0.0.8"


### PR DESCRIPTION
When using pyright a `reportPrivateImportUsage` error is raised:

<img width="1109" alt="Screenshot 2024-05-27 at 9 40 54 AM" src="https://github.com/woodruffw/ordered_enum/assets/10764579/a4d44e02-98c1-42a5-9c7b-f2baca624bdb">


Details of what is considered public and private are found [here](https://microsoft.github.io/pyright/#/typed-libraries?id=library-interface)

The important excerpt is: 

> Imported symbols are considered private by default. If they use the “import A as A” (a redundant module alias), “from X import A as A” (a redundant symbol alias), or “from . import A” forms, symbol “A” is not private unless the name begins with an underscore. If a file __init__.py uses the form “from .A import X”, symbol “A” is not private unless the name begins with an underscore (but “X” is still private). If a wildcard import (of the form “from X import *”) is used, all symbols referenced by the wildcard are not private.


This PR makes `OrderedEnum` and `ValueOrderedEnum` considered public



EDIT: also further discussion that might be interesting / useful is [here](https://github.com/microsoft/pyright/issues/5902#issuecomment-1707786473) - these rules seem to be agreed upon across type checkers.
